### PR TITLE
Fix paintGL()

### DIFF
--- a/src/MyApplication.cpp
+++ b/src/MyApplication.cpp
@@ -29,9 +29,18 @@ void MyApplication::initializeGL() {
 }
 
 void MyApplication::paintGL() {
-    GL::defaultFramebuffer.clear(GL::FramebufferClear::Color);
+	/* Reset state to avoid Qt affecting Magnum */
+	GL::Context::current().resetState(GL::Context::State::ExitExternal);
+		
+	/* Using framebuffer provided by Qt as default framebuffer */
+    auto qtDefaultFramebuffer = GL::Framebuffer::wrap(defaultFramebufferObject(), {{}, {width(), height()}});
+
+    qtDefaultFramebuffer.clear(GL::FramebufferClear::Color);
 
     /* TODO: Add your drawing code here */
+	
+	/* Clean up Magnum state and back to Qt */
+	GL::Context::current().resetState(GL::Context::State::EnterExternal);
 }
 
 int main(int argc, char** argv) {

--- a/src/MyApplication.cpp
+++ b/src/MyApplication.cpp
@@ -29,18 +29,18 @@ void MyApplication::initializeGL() {
 }
 
 void MyApplication::paintGL() {
-	/* Reset state to avoid Qt affecting Magnum */
-	GL::Context::current().resetState(GL::Context::State::ExitExternal);
+    /* Reset state to avoid Qt affecting Magnum */
+    GL::Context::current().resetState(GL::Context::State::ExitExternal);
 		
-	/* Using framebuffer provided by Qt as default framebuffer */
+    /* Using framebuffer provided by Qt as default framebuffer */
     auto qtDefaultFramebuffer = GL::Framebuffer::wrap(defaultFramebufferObject(), {{}, {width(), height()}});
 
     qtDefaultFramebuffer.clear(GL::FramebufferClear::Color);
 
     /* TODO: Add your drawing code here */
 	
-	/* Clean up Magnum state and back to Qt */
-	GL::Context::current().resetState(GL::Context::State::EnterExternal);
+    /* Clean up Magnum state and back to Qt */
+    GL::Context::current().resetState(GL::Context::State::EnterExternal);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Added `resetState()` to avoid Qt affecting Magnum.
Replaced `GL::defaultFramebuffer` by wrapped `QOpenGLWidget::defaultFramebufferObject()`
for the ability to do things like a Render-To-Texture.